### PR TITLE
Fixed issue with connect being passed port=empty string

### DIFF
--- a/sqlserver_pymssql/base.py
+++ b/sqlserver_pymssql/base.py
@@ -111,9 +111,10 @@ class DatabaseWrapper(_DatabaseWrapper):
             'host': settings_dict['HOST'],
             'database': settings_dict['NAME'],
             'user': settings_dict['USER'],
-            'password': settings_dict['PASSWORD'],
-            'port': settings_dict['PORT'],
+            'password': settings_dict['PASSWORD']
         }
+        if settings_dict['PORT']:
+            params['port'] = settings_dict['PORT']
         options = settings_dict.get('OPTIONS', {})
         params.update(options)
         return params


### PR DESCRIPTION
pymssql throws an error if you pass in port as an empty string, which is the default behavior if you don't specify a port in your database definition.  I added a simple check in the DatabaseWrapper.get_connection_params to fix this.