### PR TITLE
a more repeatable version of a deploying a README file. It uses a mai…

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include README.rst

--- a/setup.py
+++ b/setup.py
@@ -7,8 +7,9 @@ os.putenv('COPYFILE_DISABLE', 'true')
 
 # Prevent distutils from complaining that a standard file wasn't found
 README = os.path.join(os.path.dirname(__file__), 'README')
-if not os.path.exists(README):
-    os.symlink(README + '.rst', README)
+if os.path.exists(README):
+    os.remove(README)
+os.symlink(README + '.rst', README)
 
 description = ('Django database backend for Microsoft SQL Server '
                'that works on non-Windows systems.')


### PR DESCRIPTION
…nfest file to include the README.rst, then ensures the remove of the symlink (if exists) and always links it.

I was having trouble with the symlink for README getting packaged, because setuptools by default includes a README or README.txt by default and not a README.rst. Then when it unpacked and saw the broken README symlink there it would fail running the setup.py. I believe after reading the [docs](https://docs.python.org/2/distutils/sourcedist.html#manifest-template) that the solution I am proposing will help with this issue.